### PR TITLE
chore(release): 2.0.0 [skip ci]

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,10 +7,8 @@
         [
             "@semantic-release/commit-analyzer",
             {
-                "preset": "angular",
+                "preset": "conventionalcommits",
                 "releaseRules": [
-                    { "type": "docs", "scope": "README", "release": "patch" },
-                    { "type": "refactor", "release": "patch" },
                     { "scope": "no-release", "release": false }
                 ],
                 "parserOpts": {
@@ -21,12 +19,7 @@
         [
             "@semantic-release/release-notes-generator",
             {
-                "parserOpts": {
-                    "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
-                },
-                "writerOpts": {
-                    "commitsSort": ["subject", "scope"]
-                }
+                "preset": "conventionalcommits"
             }
         ],
         "@semantic-release/changelog",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [1.1.0](https://github.com/vue-modeler/model/compare/v1.0.7...v1.1.0) (2025-09-10)
+# [2.0.0](https://github.com/vue-modeler/model/compare/v1.0.7...v1.1.0) (2025-09-10)
 
 
 ### Bug Fixes
@@ -7,13 +7,11 @@
 * enhance action decorator to accept both string and symbol types ([da62a24](https://github.com/vue-modeler/model/commit/da62a24041886cd5bc43916a3643b3eaf8a296e8))
 * update .gitignore and adjust peer dependency version in package.json ([63f68df](https://github.com/vue-modeler/model/commit/63f68df6117ebfb6e2fb9dd7554de607ad4c3dff))
 * **tests:** update action decorator tests for promise handling ([367ed0f](https://github.com/vue-modeler/model/commit/367ed0fa2fbac2c6ae9d5ea76038dc474337b13a))
-* update pnpm-lock.yaml for dependency version specification ([fc52be8](https://github.com/vue-modeler/model/commit/fc52be86c31dbc333ae6ae27ab6ed98fa23c4056))
-
 
 ### Code Refactoring
 
 *  implements new way to create a model ([d98f069](https://github.com/vue-modeler/model/commit/d98f0690a049ca71d1d79ed48d1f6a327648c616))
-* **createModel:** remove export of create-model ([c263002](https://github.com/vue-modeler/model/commit/c263002d51ae38e77a0173d95b4ac04e4dfa919e))
+* **createModel:** removed from public module API ([c263002](https://github.com/vue-modeler/model/commit/c263002d51ae38e77a0173d95b4ac04e4dfa919e))
 * **decorator:** update TypeScript configuration and action decorator ([5dceb0c](https://github.com/vue-modeler/model/commit/5dceb0c53acb87fced831ecbd5ead191bb9c90f1))
 
 
@@ -24,10 +22,10 @@
 
 ### BREAKING CHANGES
 
-* **createModel:** -  createModel function removed from public module API
-* - the factory function `model` has been removed
-- the model instance is not automatically placed in the dependency container. You must put the model instance into the container yourself when configuring dependencies.
-- dependency on vue-modeler/dc has been removed
+* createModel function removed from public module API
+* the factory function `model` has been removed
+* the model instance is not automatically placed in the dependency container. You must put the model instance into the container yourself when configuring dependencies.
+* dependency on vue-modeler/dc has been removed
 * **decorator:** used new syntax for `action` decorator based on Decorator Proposal for TC39. It is not compatible with TypeScript experimental decorator. New syntax working only with TypeScript >= 5.0. see https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#decorators
 
 # [1.1.0-beta.1](https://github.com/vue-modeler/model/compare/v1.0.7-beta.6...v1.1.0-beta.1) (2025-09-10)
@@ -58,23 +56,6 @@
 * the factory function `model` has been removed
 * the model instance is not automatically placed in the dependency container. You must put the model instance into the container yourself when configuring dependencies.
 * dependency on vue-modeler/dc has been removed
-
-
-## [1.0.7-beta.5](https://github.com/vue-modeler/model/compare/v1.0.7-beta.4...v1.0.7-beta.5) (2025-08-19)
-
-
-### Bug Fixes
-
-* **tests:** update action decorator tests for promise handling ([367ed0f](https://github.com/vue-modeler/model/commit/367ed0fa2fbac2c6ae9d5ea76038dc474337b13a))
-
-
-### Code Refactoring
-
-* **decorator:** update TypeScript configuration and action decorator ([5dceb0c](https://github.com/vue-modeler/model/commit/5dceb0c53acb87fced831ecbd5ead191bb9c90f1))
-
-
-### BREAKING CHANGES
-
 * **decorator:** used new syntax for `action` decorator based on Decorator Proposal for TC39. It is not compatible with TypeScript experimental decorator. New syntax working only with TypeScript >= 5.0. see https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#decorators
 
 ## [1.0.7-beta.4](https://github.com/vue-modeler/model/compare/v1.0.7-beta.3...v1.0.7-beta.4) (2025-08-15)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@vue-modeler/model",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A state management library based on models for Vue.js",
   "author": "abratko",
   "license": "MIT",
@@ -28,6 +28,7 @@
     "@types/node": "^22.14.0",
     "@vitest/coverage-v8": "2.1.3",
     "@vue/test-utils": "^1.3.6",
+    "conventional-changelog-conventionalcommits": "^9.1.0",
     "eslint": "^9.23.0",
     "eslint-scope": "^8.3.0",
     "eslint-visitor-keys": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@vue/test-utils':
         specifier: ^1.3.6
         version: 1.3.6(vue-template-compiler@2.7.16)(vue@2.7.16)
+      conventional-changelog-conventionalcommits:
+        specifier: ^9.1.0
+        version: 9.1.0
       eslint:
         specifier: ^9.23.0
         version: 9.23.0
@@ -1008,6 +1011,10 @@ packages:
 
   conventional-changelog-angular@8.0.0:
     resolution: {integrity: sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@9.1.0:
+    resolution: {integrity: sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==}
     engines: {node: '>=18'}
 
   conventional-changelog-writer@8.0.1:
@@ -3702,6 +3709,10 @@ snapshots:
       proto-list: 1.2.4
 
   conventional-changelog-angular@8.0.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.1.0:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
# [2.0.0](https://github.com/vue-modeler/model/compare/v1.0.7...v2.0.0) (2025-09-10)

### Breaking Changes

* Updated release configuration to use "conventionalcommits" preset for semantic-release.
* Version bump to 2.0.0, reflecting significant changes in the API and release process.
* Removed deprecated features and adjusted changelog formatting for clarity.

### Dependencies

* Added `conventional-changelog-conventionalcommits` as a dependency for improved changelog generation.